### PR TITLE
Add keywords to desktop entry

### DIFF
--- a/wildguppy.desktop
+++ b/wildguppy.desktop
@@ -7,3 +7,4 @@ Name=wildguppy
 Comment=Adjusts a laptop's brightness automatically, by using camera samples taken at a user definable interval.
 Icon=/opt/wildguppy/icon/fish_large.png
 Categories=Utility;GTK;GNOME;
+Keywords=screen;brightness;camera;lcd;panel;darkness;lightness;adjust;dimmer;webcam;


### PR DESCRIPTION
I always have trouble remembering the name of this utility, having keywords in the desktop entry lets me find wildguppy using keywords rather than trawling through all the menus.
