### PR TITLE
Update wildguppy.py for Debian8

### DIFF
--- a/wildguppy.py
+++ b/wildguppy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
-import Image
-import ImageStat
+from PIL import Image
+from PIL import ImageStat
 import math
 import os
 import time


### PR DESCRIPTION
On Debian 3.16.7-ckt11-1+deb8u6 (2015-11-09) x86_64
Image and ImageState come from PIL with the package python-pil
Inspired by http://stackoverflow.com/questions/21456964/importerror-no-module-named-image this changeset fix the following error

$ wildguppy
Traceback (most recent call last):
  File "/opt/wildguppy/wildguppy.py", line 2, in <module>
    import Image
ImportError: No module named Image
